### PR TITLE
feat(onboarding): responsive and default values

### DIFF
--- a/src/components/LevelChoice/LevelPopup/LevelPopup.tsx
+++ b/src/components/LevelChoice/LevelPopup/LevelPopup.tsx
@@ -14,8 +14,12 @@ type LevelChoicePopupProps = {
 const LevelChoicePopup: React.FC<LevelChoicePopupProps> = ({handleClose}) => {
   const {setLevelChoice, setGoalChoice, levelChoice, goalChoice} =
     useLevelChoice();
-  const [levelSelected, setLevelSelected] = useState<Level>(levelChoice);
-  const [goalSelected, setGoalSelected] = useState<Goal>(goalChoice);
+  const [levelSelected, setLevelSelected] = useState<Level | undefined>(
+    levelChoice,
+  );
+  const [goalSelected, setGoalSelected] = useState<Goal | undefined>(
+    goalChoice,
+  );
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();

--- a/src/components/onboarding/onboarding.module.css
+++ b/src/components/onboarding/onboarding.module.css
@@ -20,11 +20,17 @@
   }
 
   .card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: space-between;
     position: relative;
     background: white;
     box-shadow: 0 0 25px rgba(0, 0, 0, 0.15);
-    width: 450px;
-    height: 800px;
+    width: 100%;
+    max-width: 450px;
+    min-height: 800px;
+    height: 100%;
     border-radius: 10px;
     padding: 20px;
     z-index: 200;
@@ -42,7 +48,7 @@
       gap: 6px;
       width: 220px;
       height: 8px;
-      margin: 40px auto;
+      margin: 20px auto;
 
       span {
         display: block;
@@ -84,7 +90,7 @@
       background: var(--secondary);
       color: white;
       width: 80%;
-      padding: 10px 50px;
+      padding: 10px 30px;
       border-radius: 100px;
       font-size: 1.3rem;
       font-weight: bold;
@@ -98,13 +104,9 @@
     }
 
     .skipButtonContainer {
-      position: absolute;
-      bottom: 20px;
       width: max-content;
       display: flex;
       gap: 10px;
-      left: 50%;
-      transform: translateX(-50%);
       opacity: 0.6;
 
       .skipButton {

--- a/src/components/onboarding/onboarding.module.css
+++ b/src/components/onboarding/onboarding.module.css
@@ -77,7 +77,7 @@
       background-size: 100% 100%;
 
       p {
-        width: 75%;
+        width: 95%;
         margin: 40px auto;
         padding-top: 40px;
         font-size: 18px;

--- a/src/context/LevelChoiceContext.tsx
+++ b/src/context/LevelChoiceContext.tsx
@@ -1,16 +1,27 @@
 'use client';
-import React, {createContext, useState, useContext} from 'react';
+import React, {
+  createContext,
+  useState,
+  useContext,
+  SetStateAction,
+  Dispatch,
+} from 'react';
 
 export type Level = 'Débutant' | 'Intermédiaire' | 'Avancé';
 export type Goal = 'Tourisme' | 'Long-séjour' | 'Expatrié';
 
-export const LevelChoiceContext = createContext({
-  levelChoice: 'Débutant' as Level,
-  goalChoice: 'Tourisme' as Goal,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  setLevelChoice: (levelChoice: Level) => {},
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  setGoalChoice: (goalChoice: Goal) => {},
+type LevelChoiceContextType = {
+  levelChoice: Level | undefined;
+  goalChoice: Goal | undefined;
+  setLevelChoice: Dispatch<SetStateAction<Level | undefined>>;
+  setGoalChoice: Dispatch<SetStateAction<Goal | undefined>>;
+};
+
+export const LevelChoiceContext = createContext<LevelChoiceContextType>({
+  levelChoice: undefined,
+  goalChoice: undefined,
+  setLevelChoice: () => {},
+  setGoalChoice: () => {},
 });
 
 export const useLevelChoice = () => useContext(LevelChoiceContext);
@@ -22,8 +33,8 @@ type LevelChoiceProviderProps = {
 export const LevelChoiceProvider: React.FC<LevelChoiceProviderProps> = ({
   children,
 }) => {
-  const [levelChoice, setLevelChoice] = useState<Level>('Débutant'); // Specify the type as Level
-  const [goalChoice, setGoalChoice] = useState<Goal>('Tourisme'); // Specify the type as Goal
+  const [levelChoice, setLevelChoice] = useState<Level | undefined>();
+  const [goalChoice, setGoalChoice] = useState<Goal | undefined>();
 
   return (
     <LevelChoiceContext.Provider


### PR DESCRIPTION
## 🤔 Why?

We want the app to be well displayed in mobile version, also we want the onboarding choices to not have any default values

## 💻 How?

I made a refacto of the context `LevelChoiceContext` and updated some styles in `onboarding.module.css`.

## ✅ How to validate this PR?

- Test the preview with a mobile screen (390 x 844)
